### PR TITLE
Add -fPIE FLAGS.

### DIFF
--- a/jni/vnc/Android.mk
+++ b/jni/vnc/Android.mk
@@ -76,4 +76,7 @@ LOCAL_STATIC_LIBRARIES := libjpeg libpng libssl_static libcrypto_static
 
 LOCAL_MODULE := androidvncserver
 
+LOCAL_CFLAGS += -fPIE
+LOCAL_LDFLAGS += -fPIE -pie
+
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
error: only position independent executables (PIE) are supported.
