### PR TITLE
Fixed two off-by-one errors in droidvncserver.c

### DIFF
--- a/jni/vnc/droidvncserver.c
+++ b/jni/vnc/droidvncserver.c
@@ -104,7 +104,7 @@ rfbNewClientHookPtr clientHook(rfbClientPtr cl)
   cl->clientGoneHook=(ClientGoneHookPtr)clientGone;
 
   char *header="~CONNECTED|";
-  char *msg=malloc(sizeof(char)*((strlen(cl->host)) + strlen(header)+1));
+  char *msg=malloc(sizeof(char)*((strlen(cl->host)) + strlen(header)+2));
   msg[0]='\0';
   strcat(msg,header);
   strcat(msg,cl->host);
@@ -120,7 +120,7 @@ void CutText(char* str,int len, struct _rfbClientRec* cl)
 {
   str[len]='\0';
   char *header="~CLIP|\n";
-  char *msg=malloc(sizeof(char)*(strlen(str) + strlen(header)+1));
+  char *msg=malloc(sizeof(char)*(strlen(str) + strlen(header)+2));
   msg[0]='\0';
   strcat(msg,header);
   strcat(msg,str);


### PR DESCRIPTION
the msg string is a concatenation of two strings and a '\n' character
(strlen(str1) + strlen(str2) + 1) is one byte off because the
string needs to be terminated by a NUL byte.